### PR TITLE
fix: improve Docker authentication step in GCP deployment workflow

### DIFF
--- a/.github/workflows/deploy-gcp.yml
+++ b/.github/workflows/deploy-gcp.yml
@@ -31,8 +31,8 @@ jobs:
           service_account_key: ${{ secrets.GCP_SA_KEY }}
           export_default_credentials: true
 
-      - name: Autenticar no Artifact Registry
-        run: gcloud auth configure-docker ${{ secrets.GCP_REGION }}-docker.pkg.dev
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker ${{ secrets.GCP_REGION }}-docker.pkg.dev --quiet
 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
Aligns the "Configure Docker for Artifact Registry" step with best practices by adding the `--quiet` flag to suppress unnecessary output.